### PR TITLE
Use the correct database type for timestamps

### DIFF
--- a/src/main/resources/db/migration/common/V1_0_0__create-schema.sql
+++ b/src/main/resources/db/migration/common/V1_0_0__create-schema.sql
@@ -2,5 +2,5 @@ create table revocation
 (
     id uuid not null primary key,
     uvci varchar(39) not null unique,
-	creation_date_time timestamp not null default now()
+	creation_date_time timestamptz not null default now()
 );

--- a/src/main/resources/db/migration/common/V1_0_1__kpi-log-schema.sql
+++ b/src/main/resources/db/migration/common/V1_0_1__kpi-log-schema.sql
@@ -1,7 +1,7 @@
 create table kpi
 (
     id uuid not null primary key,
-    timestamp timestamp not null default now(),
+    timestamptz timestamp not null default now(),
     type varchar(64) not null,
     value varchar(64) not null
 );


### PR DESCRIPTION
Using timestamp instead of timestamptz can lead to nasty bugs.

Use timestamptz

https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_timestamp_.28without_time_zone.29

This change also guarantees compatibility with the European Certificate https://github.com/ehn-digital-green-development/ehn-dgc-schema, which uses this format https://datatracker.ietf.org/doc/html/rfc3339#section-5.6