### PR TITLE
Set CWT issuer (claim key 1) to "CH" (ISO 3166-1 alpha-2) according to hcert_spec

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/service/CBORService.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/service/CBORService.java
@@ -23,7 +23,7 @@ public class CBORService {
     private static final Integer EXP_CLAIM_KEY = 4;
     private static final Integer HCERT_CLAIM_KEY = -260;
     private static final Integer HCERT_INNER_CLAIM_KEY = 1;
-    private static final String ISSUER = "CH BAG";
+    private static final String ISSUER = "CH";
     // Signature Data (Sig_structure)
     private static final String CONTEXT = "Signature1";
     private static final byte[] EXTERNAL_AAD = new byte[0];

--- a/src/test/java/ch/admin/bag/covidcertificate/service/CBORServiceTest.java
+++ b/src/test/java/ch/admin/bag/covidcertificate/service/CBORServiceTest.java
@@ -62,7 +62,7 @@ class CBORServiceTest {
         // then
         assertNotNull(result);
         CBORObject resultCBORObject = CBORObject.DecodeFromBytes(result);
-        assertEquals("CH BAG", resultCBORObject.get(1).AsString());
+        assertEquals("CH", resultCBORObject.get(1).AsString());
         assertEquals(issuedAt, instantConverter.FromCBORObject(resultCBORObject.get(6)));
         assertEquals(expiration, instantConverter.FromCBORObject(resultCBORObject.get(4)));
         assertArrayEquals(hcert, resultCBORObject.get(-260).get(1).EncodeToBytes());


### PR DESCRIPTION
The hcert specification (https://github.com/ehn-dcc-development/hcert-spec/blob/main/hcert_spec.md) specifies the `iss` (issuer) claim to be of format `ISO 3166-1 alpha-2`.

> The Issuer (iss) claim is a string value that MAY optionally hold the ISO 3166-1 alpha-2 Country Code of the entity issuing the health certificate. This claim can be used by a Verifier to identify which set of DSCs to use for validation. The Claim Key 1 is used to identify this claim.