### PR TITLE
Set TestType for rapid tests

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/api/mapper/IssuableRapidTestMapper.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/api/mapper/IssuableRapidTestMapper.java
@@ -1,6 +1,7 @@
 package ch.admin.bag.covidcertificate.api.mapper;
 
 import ch.admin.bag.covidcertificate.api.valueset.IssuableTestDto;
+import ch.admin.bag.covidcertificate.api.valueset.TestType;
 import ch.admin.bag.covidcertificate.domain.RapidTest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,7 @@ import java.util.stream.Collectors;
 public class IssuableRapidTestMapper {
 
     public static IssuableTestDto fromRapidTest(RapidTest rapidTest) {
-        return new IssuableTestDto(rapidTest.getCode(), rapidTest.getDisplay(), null);
+        return new IssuableTestDto(rapidTest.getCode(), rapidTest.getDisplay(), TestType.RAPID_TEST);
     }
 
     public static List<IssuableTestDto> fromRapidTests(List<RapidTest> rapidTests) {


### PR DESCRIPTION
Fix the NullPointerException while creating test certificates.