### PR TITLE
VACCINECERT-1655_Antibody_min_date

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/api/Constants.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/api/Constants.java
@@ -78,6 +78,7 @@ public class Constants {
     public static final CreateCertificateError INVALID_PRINT_FOR_TEST = new CreateCertificateError(488, "Print is not available for test certificates", HttpStatus.BAD_REQUEST);
     public static final CreateCertificateError INVALID_DATE_OF_BIRTH_IN_FUTURE = new CreateCertificateError(489, "Invalid dateOfBirth! Date cannot be in the future", HttpStatus.BAD_REQUEST);
     public static final CreateCertificateError NO_ANTIBODY_DATA = new CreateCertificateError(490, "No antibody data specified", HttpStatus.BAD_REQUEST);
+    public static final CreateCertificateError INVALID_ANTIBODY_SAMPLE_DATE_TIME = new CreateCertificateError(491, "Date of sample collection must not be before 16.11.2021", HttpStatus.BAD_REQUEST);
 
 
     public static final RevocationError DUPLICATE_UVCI = new RevocationError(480, "Duplicate UVCI.", HttpStatus.CONFLICT);

--- a/src/main/java/ch/admin/bag/covidcertificate/api/request/AntibodyCertificateDataDto.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/api/request/AntibodyCertificateDataDto.java
@@ -21,9 +21,14 @@ public class AntibodyCertificateDataDto {
     private LocalDate sampleDate;
     private String testingCenterOrFacility;
 
+    private static final LocalDate ANTIBODY_MIN_DATE = LocalDate.of(2021, 11, 16);
+
     public void validate(SystemSource systemSource) {
         if (sampleDate == null || sampleDate.isAfter(LocalDate.now())) {
             throw new CreateCertificateException(INVALID_SAMPLE_DATE_TIME);
+        }
+        if (sampleDate.isBefore(ANTIBODY_MIN_DATE)) {
+            throw new CreateCertificateException(INVALID_ANTIBODY_SAMPLE_DATE_TIME);
         }
         if (!StringUtils.hasText(testingCenterOrFacility) || testingCenterOrFacility.length() > MAX_STRING_LENGTH) {
             throw new CreateCertificateException(INVALID_TEST_CENTER);


### PR DESCRIPTION
Antibody certificates cannot be issued prior to 16.1.2021. Also with corresponding error message.