### PR TITLE
VACCINECERT-1839 wrong userExtId used

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/api/Constants.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/api/Constants.java
@@ -37,6 +37,7 @@ public class Constants {
     public static final String KPI_TYPE_EXCEPTIONAL = "me";
     public static final String KPI_TYPE_INAPP_DELIVERY = "ad";
     public static final String USER_EXT_ID_CLAIM_KEY = "userExtId";
+    public static final String PREFERRED_USERNAME_CLAIM_KEY = "preferred_username";
     public static final String KPI_UUID_KEY = "uuid";
     public static final String KPI_TIMESTAMP_KEY = "ts";
     public static final String KPI_TYPE_KEY = "type";

--- a/src/main/java/ch/admin/bag/covidcertificate/config/security/authentication/ServletJeapAuthorization.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/config/security/authentication/ServletJeapAuthorization.java
@@ -2,7 +2,7 @@ package ch.admin.bag.covidcertificate.config.security.authentication;
 
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import static ch.admin.bag.covidcertificate.api.Constants.USER_EXT_ID_CLAIM_KEY;
+import static ch.admin.bag.covidcertificate.api.Constants.PREFERRED_USERNAME_CLAIM_KEY;
 
 /**
  * This class provides methods to support authorization needs based on the current security context for Spring WebMvc applications.
@@ -27,7 +27,7 @@ public class ServletJeapAuthorization {
         var authentication = (JeapAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
         var jwt = authentication.getToken();
         if (jwt != null) {
-            return jwt.getClaimAsString(USER_EXT_ID_CLAIM_KEY);
+            return jwt.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY);
         }
         return null;
     }

--- a/src/main/java/ch/admin/bag/covidcertificate/service/KpiDataService.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/service/KpiDataService.java
@@ -76,10 +76,10 @@ public class KpiDataService {
 
     private void logCertificateGenerationKpi(String type, String uvci, String details, String country) {
         Jwt token = jeapAuthorization.getJeapAuthenticationToken().getToken();
-        if (token != null && token.getClaimAsString(USER_EXT_ID_CLAIM_KEY) != null) {
+        if (token != null && token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY) != null) {
             var kpiTimestamp = LocalDateTime.now();
             writeKpiInLog(type, details, country, kpiTimestamp, token);
-            saveKpiData(new KpiData(kpiTimestamp, type, token.getClaimAsString(USER_EXT_ID_CLAIM_KEY), uvci, details, country));
+            saveKpiData(new KpiData(kpiTimestamp, type, token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY), uvci, details, country));
         }
     }
 
@@ -89,7 +89,7 @@ public class KpiDataService {
         var kpiTypeKVPair =kv(KPI_TYPE_KEY, type);
         var kpiDetailsKVPair = kv(KPI_DETAILS, details);
         var kpiCountryKVPair = kv(KPI_COUNTRY, country);
-        var uuidKVPair = kv(KPI_UUID_KEY, token.getClaimAsString(USER_EXT_ID_CLAIM_KEY));
+        var uuidKVPair = kv(KPI_UUID_KEY, token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY));
 
         if(details == null){
             log.info("kpi: {} {} {} {} {}", timestampKVPair, systemKVPair, kpiTypeKVPair, uuidKVPair, kpiCountryKVPair);

--- a/src/main/java/ch/admin/bag/covidcertificate/web/controller/OneTimePasswordController.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/web/controller/OneTimePasswordController.java
@@ -41,10 +41,10 @@ public class OneTimePasswordController {
 
         Jwt token = jeapAuthorization.getJeapAuthenticationToken().getToken();
 
-        String otp = customTokenProvider.createToken(token.getClaimAsString(USER_EXT_ID_CLAIM_KEY), token.getClaimAsString("homeName"));
+        String otp = customTokenProvider.createToken(token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY), token.getClaimAsString("homeName"));
         LocalDateTime kpiTimestamp = LocalDateTime.now();
-        log.info("kpi: {} {} {}", kv(KPI_TIMESTAMP_KEY, ZonedDateTime.now(SWISS_TIMEZONE).format(LOG_FORMAT)), kv(KPI_OTP_SYSTEM_KEY, KPI_SYSTEM_UI), kv(KPI_UUID_KEY, token.getClaimAsString(USER_EXT_ID_CLAIM_KEY)));
-        kpiLogService.saveKpiData(new KpiData(kpiTimestamp, KPI_OTP_SYSTEM_KEY, token.getClaimAsString(USER_EXT_ID_CLAIM_KEY)));
+        log.info("kpi: {} {} {}", kv(KPI_TIMESTAMP_KEY, ZonedDateTime.now(SWISS_TIMEZONE).format(LOG_FORMAT)), kv(KPI_OTP_SYSTEM_KEY, KPI_SYSTEM_UI), kv(KPI_UUID_KEY, token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY)));
+        kpiLogService.saveKpiData(new KpiData(kpiTimestamp, KPI_OTP_SYSTEM_KEY, token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY)));
         return otp;
     }
 

--- a/src/main/java/ch/admin/bag/covidcertificate/web/controller/RevocationController.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/web/controller/RevocationController.java
@@ -26,7 +26,7 @@ import static ch.admin.bag.covidcertificate.api.Constants.KPI_SYSTEM_UI;
 import static ch.admin.bag.covidcertificate.api.Constants.KPI_TIMESTAMP_KEY;
 import static ch.admin.bag.covidcertificate.api.Constants.KPI_UUID_KEY;
 import static ch.admin.bag.covidcertificate.api.Constants.LOG_FORMAT;
-import static ch.admin.bag.covidcertificate.api.Constants.USER_EXT_ID_CLAIM_KEY;
+import static ch.admin.bag.covidcertificate.api.Constants.PREFERRED_USERNAME_CLAIM_KEY;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 @RestController
@@ -53,10 +53,10 @@ public class RevocationController {
 
     private void logKpi(String uvci) {
         Jwt token = jeapAuthorization.getJeapAuthenticationToken().getToken();
-        if (token != null && token.getClaimAsString(USER_EXT_ID_CLAIM_KEY) != null) {
+        if (token != null && token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY) != null) {
             LocalDateTime kpiTimestamp = LocalDateTime.now();
-            log.info("kpi: {} {} {}", kv(KPI_TIMESTAMP_KEY, kpiTimestamp.format(LOG_FORMAT)), kv(KPI_REVOKE_CERTIFICATE_SYSTEM_KEY, KPI_SYSTEM_UI), kv(KPI_UUID_KEY, token.getClaimAsString(USER_EXT_ID_CLAIM_KEY)));
-            kpiLogService.saveKpiData(new KpiData(kpiTimestamp, KPI_REVOKE_CERTIFICATE_SYSTEM_KEY, token.getClaimAsString(USER_EXT_ID_CLAIM_KEY), uvci, null, null));
+            log.info("kpi: {} {} {}", kv(KPI_TIMESTAMP_KEY, kpiTimestamp.format(LOG_FORMAT)), kv(KPI_REVOKE_CERTIFICATE_SYSTEM_KEY, KPI_SYSTEM_UI), kv(KPI_UUID_KEY, token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY)));
+            kpiLogService.saveKpiData(new KpiData(kpiTimestamp, KPI_REVOKE_CERTIFICATE_SYSTEM_KEY, token.getClaimAsString(PREFERRED_USERNAME_CLAIM_KEY), uvci, null, null));
         }
     }
 }


### PR DESCRIPTION
ExtId now gets read out correctly from Oauth token and will be used for KPI logging and OTP generation as intended