### PR TITLE
VACCINECER-2160 init certificate alias locally

### DIFF
--- a/src/main/resources/db/migration/local/V1_0_52__update_signing_information_with_mock_certificate_alias.sql
+++ b/src/main/resources/db/migration/local/V1_0_52__update_signing_information_with_mock_certificate_alias.sql
@@ -1,0 +1,4 @@
+UPDATE signing_information
+SET certificate_alias = 'mock'
+WHERE certificate_alias is null
+;


### PR DESCRIPTION
Because of [#321](https://github.com/admin-ch/CovidCertificate-Management-Service/pull/321) we can't create certificates anymore in local environment. Initialising the `certificate_alias` in the local DB solves that problem.