### PR TITLE
Feature/vaccinecer-2140  define logging for eu rat

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/api/Constants.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/api/Constants.java
@@ -38,7 +38,7 @@ public class Constants {
     public static final String KPI_TYPE_VACCINATION_TOURIST = "vt";
     public static final String KPI_TYPE_TEST = "t";
     public static final String KPI_TYPE_RECOVERY = "r";
-    public static final String KPI_TYPE_RECOVERY_RAT_EU = "rr-eu";
+    public static final String KPI_TYPE_RECOVERY_RAT_EU = "rreu";
     public static final String KPI_TYPE_ANTIBODY = "a";
     public static final String KPI_TYPE_EXCEPTIONAL = "me";
     public static final String KPI_TYPE_IN_APP_DELIVERY = "ad";


### PR DESCRIPTION
The report-service uses enums for the KPI types. And Java enums don't like hyphens, so we switch to a type without hyphen to avoid future problems :) 

(EU RAT is not yet in PROD, so we don't need to worry about data migration in PROD)