### PR TITLE
Feature/vaccinecer 2334 zertifikat generieren führt bei name mit nbsp zu textfehlern im pdf

### DIFF
--- a/src/main/java/ch/admin/bag/covidcertificate/api/request/CovidCertificatePersonNameDto.java
+++ b/src/main/java/ch/admin/bag/covidcertificate/api/request/CovidCertificatePersonNameDto.java
@@ -24,11 +24,12 @@ public class CovidCertificatePersonNameDto {
     private String givenName;
 
     public void validate() {
-        if (!StringUtils.hasText(givenName) || givenName.length() > MAX_STRING_LENGTH) {
-            throw new CreateCertificateException(INVALID_GIVEN_NAME);
-        }
-        if (!StringUtils.hasText(familyName) || familyName.length() > MAX_STRING_LENGTH) {
+        if (familyName == null) {
             throw new CreateCertificateException(INVALID_FAMILY_NAME);
+        }
+
+        if (givenName == null) {
+            throw new CreateCertificateException(INVALID_GIVEN_NAME);
         }
 
         Matcher givenNameMatcher = invalidCharactersRegex.matcher(givenName);
@@ -38,6 +39,16 @@ public class CovidCertificatePersonNameDto {
 
         Matcher familyNameMatcher = invalidCharactersRegex.matcher(familyName);
         if(familyNameMatcher.find()) {
+            throw new CreateCertificateException(INVALID_FAMILY_NAME);
+        }
+
+        familyName = familyName.replaceAll("\\h", " ").trim();
+        givenName = givenName.replaceAll("\\h", " ").trim();
+
+        if (!StringUtils.hasText(givenName) || givenName.length() > MAX_STRING_LENGTH) {
+            throw new CreateCertificateException(INVALID_GIVEN_NAME);
+        }
+        if (!StringUtils.hasText(familyName) || familyName.length() > MAX_STRING_LENGTH) {
             throw new CreateCertificateException(INVALID_FAMILY_NAME);
         }
 

--- a/src/test/java/ch/admin/bag/covidcertificate/api/CovidCertificatePersonNameDtoTest.java
+++ b/src/test/java/ch/admin/bag/covidcertificate/api/CovidCertificatePersonNameDtoTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 
 import static ch.admin.bag.covidcertificate.api.Constants.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @Tag("CovidCertificatePersonNameDtoTest")
 @DisplayName("Tests for the CovidCertificatePersonNameDto")
@@ -75,6 +76,15 @@ public class CovidCertificatePersonNameDtoTest {
             var covidCertificatePersonNameDto = new CovidCertificatePersonNameDto("f".repeat(length), validGivenName);
             assertInvalidFamilyName(covidCertificatePersonNameDto);
         }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"Hans Ueli", " Hans Ueli ", " Hans\tUeli"})
+        @DisplayName("Given 'familyName' contain an none-breaking characters, tabs or is untrimmed, when validated, it sanitize the 'familyName'.")
+        void validationTest7(String unsanitizedName) {
+            var covidCertificatePersonNameDto = new CovidCertificatePersonNameDto(unsanitizedName, validGivenName);
+            assertDoesNotThrow(covidCertificatePersonNameDto::validate);
+            assertEquals("Hans Ueli", covidCertificatePersonNameDto.getFamilyName());
+        }
     }
 
     @Nested
@@ -112,6 +122,15 @@ public class CovidCertificatePersonNameDtoTest {
         void validationTest8(int length) {
             var covidCertificatePersonNameDto = new CovidCertificatePersonNameDto(validFamilyName, "g".repeat(length));
             assertInvalidGivenName(covidCertificatePersonNameDto);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"Franz Mann", " Franz Mann ", " Franz\tMann"})
+        @DisplayName("Given 'givenName' contain an none-breaking characters, tabs or is untrimmed, when validated, it sanitize the 'givenName'.")
+        void validationTest9(String unsanitizedName) {
+            var covidCertificatePersonNameDto = new CovidCertificatePersonNameDto(validFamilyName, unsanitizedName);
+            assertDoesNotThrow(covidCertificatePersonNameDto::validate);
+            assertEquals("Franz Mann", covidCertificatePersonNameDto.getGivenName());
         }
     }
 }


### PR DESCRIPTION
- adjusting CovidCertificatePersonNameDto::validate() which removes none-breaking characters when generating a single PDF or when using a massgeneration with a CSV upload
- New unit tests which ensures that none-breaking characters are removed from the first-/lastname