### PR TITLE
correcting unit test for java 17

### DIFF
--- a/src/test/java/ch/admin/bag/covidcertificate/domain/RapidTestRepositoryIntegrationTest.java
+++ b/src/test/java/ch/admin/bag/covidcertificate/domain/RapidTestRepositoryIntegrationTest.java
@@ -40,8 +40,9 @@ class RapidTestRepositoryIntegrationTest {
     @Transactional
     void givenRapidTestsInDB_whenFindAllByActiveAndModifiedAtIsNot_thenReturnRapidTest() {
         // given
-        LocalDateTime modifiedAt = LocalDateTime.now().minusDays(1);
-        LocalDateTime current = LocalDateTime.now();
+        final var current = LocalDateTime.now().withNano(0);
+        final var modifiedAt = current.minusDays(1);
+
         persistRapidTest("1", true, modifiedAt);
         persistRapidTest("2", true, modifiedAt);
         persistRapidTest("3", true, current);


### PR DESCRIPTION
In java 17 the accuracy of LocalDateTime is in nanoseconds. The H2 database / SQL Standard by default stores the timestamp with a lower accuracy. This can case problems, if the LocalDateTime is stored and then searched. Since it was stored with a lower accuracy there will be no match!

The API and UI itself demands an accuracy of milliseconds which means that the backend won't cause any trouble as the nanosecond part will be filled with 0 and when stored even ignored.